### PR TITLE
fix: remove leading double space in CHANGES entry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## 1.1.1 (2026-02-19)
 
--  Don't crash when doing quiet hatch build 
+- Don't crash when doing quiet hatch build 
 
 ## 1.1.0 (2024-04-24)
 


### PR DESCRIPTION
Fixes a minor formatting issue in CHANGES.md where a line
began with two leading spaces, causing inconsistent rendering and a
potentially confusing diff.